### PR TITLE
feat(api-blogs/comment): group comments by parent

### DIFF
--- a/apps/api-blog/api/gorm_repository/comment.go
+++ b/apps/api-blog/api/gorm_repository/comment.go
@@ -40,7 +40,15 @@ func (r *CommentGormRepo) GetAllComments(query *entities.CommentQuery) (common.B
 		return res, err
 	}
 
-	res.Items = comments
+	commentFilter := []entities.Comment{}
+
+	for _, item := range comments {
+		if len(item.Replies) > 0 {
+			commentFilter = append(commentFilter, item)
+		}
+	}
+
+	res.Items = commentFilter
 
 	return res, nil
 }

--- a/apps/api-blog/api/gorm_repository/comment.go
+++ b/apps/api-blog/api/gorm_repository/comment.go
@@ -33,10 +33,13 @@ func (r *CommentGormRepo) GetAllComments(query *entities.CommentQuery) (common.B
 	cond := &entities.Comment{UserID: query.UserID, PostID: query.PostID, ParentID: parentIDaddr}
 
 	if err := r.db.Scopes(scopes.Pagination(r.db, entities.Comment{}, query.BaseQuery, &res)).
+		Preload("Replies.User").
+		Preload("Replies.Replies").
 		Preload(clause.Associations).
 		Find(&comments, cond).Error; err != nil {
 		return res, err
 	}
+
 	res.Items = comments
 
 	return res, nil

--- a/apps/api-blog/api/handler/comment.go
+++ b/apps/api-blog/api/handler/comment.go
@@ -27,7 +27,7 @@ func NewCommentHandler(usecase usecase.CommentUsecase) *CommentHandler {
 // @Param  pageSize query int false "Page Size"
 // @Param sort query string false "Sort direction" Enums(asc, desc) default(desc)
 // @Param sortBy query string false "Sort by" Enums(id, user_id, parent_id) default(id)
-// @Success 200 {object} common.BasePaginationResponse[entities.CommentResponse]
+// @Success 200 {object} common.BasePaginationResponse[entities.Comment]
 // @Failure 404
 // @Failure 500
 // @Router /comments/ [get]
@@ -54,18 +54,7 @@ func (handler *CommentHandler) GetAllComments(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusNotFound, "failed to get all comments")
 	}
 
-	commentRes := common.BasePaginationResponse[entities.CommentResponse]{
-		Items: []entities.CommentResponse{},
-	}
-	commentRes.Page = comments.Page
-	commentRes.PageSize = comments.PageSize
-	commentRes.Total = comments.Total
-
-	for _, comment := range comments.Items {
-		commentRes.Items = append(commentRes.Items, comment.ToResponse())
-	}
-
-	return c.Status(fiber.StatusOK).JSON(commentRes)
+	return c.Status(fiber.StatusOK).JSON(comments)
 }
 
 // @CreateComment godoc
@@ -74,7 +63,7 @@ func (handler *CommentHandler) GetAllComments(c *fiber.Ctx) error {
 // @Tags Comments
 // @Accept json
 // @Param comment body entities.CommentRequest true "Comment"
-// @Success 201 {object} entities.CommentResponse
+// @Success 201 {object} entities.Comment
 // @Failure 400
 // @Failure 500
 // @Security ApiKeyAuth
@@ -93,7 +82,7 @@ func (handler *CommentHandler) CreateComment(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to create new comment")
 	}
 
-	return c.Status(fiber.StatusCreated).JSON(comment.ToResponse())
+	return c.Status(fiber.StatusCreated).JSON(comment)
 }
 
 // @UpdateComment godoc
@@ -102,7 +91,7 @@ func (handler *CommentHandler) CreateComment(c *fiber.Ctx) error {
 // @Param id path int true "Comment ID"
 // @Param comment body handler.UpdateComment.commentRequest true "Comment"
 // @Tags Comments
-// @Success 200 {object} entities.CommentResponse
+// @Success 200 {object} entities.Comment
 // @Failure 400
 // @Failure 500
 // @Security ApiKeyAuth
@@ -130,7 +119,7 @@ func (handler *CommentHandler) UpdateComment(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to update specfied comment")
 	}
 
-	return c.Status(fiber.StatusOK).JSON(comment.ToResponse())
+	return c.Status(fiber.StatusOK).JSON(comment)
 }
 
 // @DeleteComment godoc
@@ -139,7 +128,7 @@ func (handler *CommentHandler) UpdateComment(c *fiber.Ctx) error {
 // @Param id path int true "Comment ID"
 // @Tags Comments
 // @Produce json
-// @Success 200 {object} entities.CommentResponse
+// @Success 200 {object} entities.Comment
 // @Failure 400
 // @Failure 500
 // @security ApiKeyAuth
@@ -157,5 +146,5 @@ func (handler *CommentHandler) DeleteComment(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to delete specfied comment")
 	}
 
-	return c.Status(fiber.StatusOK).JSON(comment.ToResponse())
+	return c.Status(fiber.StatusOK).JSON(comment)
 }

--- a/apps/api-blog/api/handler/post.go
+++ b/apps/api-blog/api/handler/post.go
@@ -79,7 +79,7 @@ func (handler *PostHandler) GetAllPosts(c *fiber.Ctx) error {
 // @Description Get post by slug
 // @Tags Posts
 // @Param slug path string true "Post Slug"
-// @Success 200 {object} entities.PostDetailResponse
+// @Success 200 {object} entities.PostResponse
 // @Failure 400
 // @Failure 404
 // @Router /posts/{slug} [get]
@@ -91,7 +91,7 @@ func (handler *PostHandler) GetPostBySlug(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusNotFound, "failed to get post")
 	}
 
-	return c.Status(fiber.StatusOK).JSON(post.ToDetailResponse())
+	return c.Status(fiber.StatusOK).JSON(post.ToResponse())
 }
 
 // @CreatePost godoc
@@ -100,7 +100,7 @@ func (handler *PostHandler) GetPostBySlug(c *fiber.Ctx) error {
 // @Tags Posts
 // @Accept json
 // @Param post body entities.PostRequest true "Post"
-// @Success 201 {object} entities.PostDetailResponse
+// @Success 201 {object} entities.PostResponse
 // @Failure 400
 // @Failure 409
 // @Failure 500
@@ -138,7 +138,7 @@ func (handler *PostHandler) CreatePost(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to create post slug")
 	}
 
-	return c.Status(fiber.StatusCreated).JSON(post.ToDetailResponse())
+	return c.Status(fiber.StatusCreated).JSON(post.ToResponse())
 }
 
 // @UpdatePost godoc
@@ -147,7 +147,7 @@ func (handler *PostHandler) CreatePost(c *fiber.Ctx) error {
 // @Param id path int true "Post ID"
 // @Param post body entities.PostRequest true "Post"
 // @Tags Posts
-// @Success 200 {object} entities.PostDetailResponse
+// @Success 200 {object} entities.PostResponse
 // @Failure 400
 // @Failure 500
 // @Security ApiKeyAuth
@@ -181,7 +181,7 @@ func (handler *PostHandler) UpdatePost(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to create new slug")
 	}
 
-	return c.Status(fiber.StatusOK).JSON(post.ToDetailResponse())
+	return c.Status(fiber.StatusOK).JSON(post.ToResponse())
 }
 
 // @DeletePost godoc
@@ -190,7 +190,7 @@ func (handler *PostHandler) UpdatePost(c *fiber.Ctx) error {
 // @Param id path int true "Post ID"
 // @Tags Posts
 // @Produce json
-// @Success 200 {object} entities.PostDetailResponse
+// @Success 200 {object} entities.PostResponse
 // @Failure 400
 // @Failure 500
 // @security ApiKeyAuth
@@ -208,5 +208,5 @@ func (handler *PostHandler) DeletePost(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to delete specfied post")
 	}
 
-	return c.Status(fiber.StatusOK).JSON(post.ToDetailResponse())
+	return c.Status(fiber.StatusOK).JSON(post.ToResponse())
 }

--- a/apps/api-blog/pkg/entities/comment.go
+++ b/apps/api-blog/pkg/entities/comment.go
@@ -9,37 +9,31 @@ import (
 
 type Comment struct {
 	ID        uint           `json:"id"`
-	UserID    uint           `json:"userId"`
-	User      User           `json:"-"`
+	UserID    uint           `json:"-"`
+	User      User           `json:"user"`
 	PostID    uint           `json:"postId"`
 	Post      Post           `json:"-"`
-	ParentID  *uint          `json:"parentId"`
-	Parent    *Comment       `json:"-"`
+	ParentID  *uint          `json:"-"`
+	Replies   []Comment      `json:"replies" gorm:"foreignkey:ParentID"`
 	Content   string         `gorm:"size:1000" json:"content"`
 	CreatedAt time.Time      `json:"createdAt"`
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `json:"-"`
 }
 
-type CommentResponse struct {
-	ID        uint      `json:"id"`
-	User      User      `json:"user"`
-	Parent    *Comment  `json:"parent"`
-	PostID    uint      `json:"postId"`
-	Content   string    `gorm:"size:1000" json:"content"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
-}
-
-func (comment *Comment) ToResponse() CommentResponse {
-	return CommentResponse{
+func (comment *Comment) New() Comment {
+	return Comment{
 		ID:        comment.ID,
-		PostID:    comment.PostID,
+		UserID:    comment.UserID,
 		User:      comment.User,
-		Parent:    comment.Parent,
+		PostID:    comment.PostID,
+		Post:      comment.Post,
+		ParentID:  comment.ParentID,
+		Replies:   comment.Replies,
 		Content:   comment.Content,
 		CreatedAt: comment.CreatedAt,
 		UpdatedAt: comment.UpdatedAt,
+		DeletedAt: comment.DeletedAt,
 	}
 }
 

--- a/apps/api-blog/pkg/entities/post.go
+++ b/apps/api-blog/pkg/entities/post.go
@@ -41,11 +41,6 @@ type PostResponse struct {
 	UpdatedAt    time.Time  `json:"updatedAt"`
 }
 
-type PostDetailResponse struct {
-	PostResponse
-	Comments []Comment `json:"comments"`
-}
-
 func (post *Post) ToResponse() PostResponse {
 	return PostResponse{
 		ID:           post.ID,
@@ -60,26 +55,6 @@ func (post *Post) ToResponse() PostResponse {
 		PublishedAt:  post.PublishedAt,
 		CreatedAt:    post.CreatedAt,
 		UpdatedAt:    post.UpdatedAt,
-	}
-}
-
-func (post *Post) ToDetailResponse() PostDetailResponse {
-	return PostDetailResponse{
-		PostResponse: PostResponse{
-			ID:           post.ID,
-			User:         post.User,
-			Parent:       post.Parent,
-			Title:        post.Title,
-			Slug:         post.Slug,
-			Image:        post.Image,
-			CommentCount: post.CommentCount,
-			Content:      post.Content,
-			Published:    post.Published,
-			PublishedAt:  post.PublishedAt,
-			CreatedAt:    post.CreatedAt,
-			UpdatedAt:    post.UpdatedAt,
-		},
-		Comments: post.Comments,
 	}
 }
 


### PR DESCRIPTION
Comments now take a new field called `replies` representing all of their replies followed by a parent.