### PR TITLE
fix(api-blogs/comment): wrong filter logic

### DIFF
--- a/apps/api-blog/api/gorm_repository/comment.go
+++ b/apps/api-blog/api/gorm_repository/comment.go
@@ -43,7 +43,7 @@ func (r *CommentGormRepo) GetAllComments(query *entities.CommentQuery) (common.B
 	commentFilter := []entities.Comment{}
 
 	for _, item := range comments {
-		if len(item.Replies) > 0 {
+		if item.ParentID == nil {
 			commentFilter = append(commentFilter, item)
 		}
 	}


### PR DESCRIPTION
Comments should return those which don't have `parentID`.